### PR TITLE
biulding with standart packets

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -45,7 +45,7 @@ REPO_ROOT=/var/www/html/repos/clickhouse
 export THREADS=$(grep -c ^processor /proc/cpuinfo)
 
 # Build most libraries using default GCC
-export PATH=${PATH/"/usr/local/bin:"/}:/usr/local/bin
+export PATH=${PATH/"/usr/local/bin:"/}:/opt/rh/devtoolset-6/root/usr/bin
 
 # Determine RHEL major version
 RHEL_VERSION=`rpm -qa --queryformat '%{VERSION}\n' '(redhat|sl|slf|centos|oraclelinux|goslinux)-release(|-server|-workstation|-client|-computenode)'`
@@ -67,16 +67,15 @@ if [ $RHEL_VERSION == 7 ]; then
 fi
 
 # Install development packages
-if ! sudo yum -y install $DISTRO_PACKAGES rpm-build redhat-rpm-config gcc-c++ readline-devel\
-  unixODBC-devel subversion python-devel git wget openssl-devel m4 createrepo glib2-devel\
-  libicu-devel zlib-devel libtool-ltdl-devel openssl-devel
+if ! sudo yum -y install $DISTRO_PACKAGES rpm-build redhat-rpm-config readline-devel mongo-cxx-driver centos-release-scl\
+  unixODBC-devel subversion cmake python boost boost-devel python-devel git wget openssl-devel m4 createrepo glib2-devel\
+  libicu-devel zlib-devel libtool-ltdl-devel openssl-devel && sudo yum -y install devtoolset-6-gcc*
 then exit 1
 fi
 
 if [ $RHEL_VERSION == 7 ]; then
   # Connect EPEL repository for CentOS 7 (for scons)
-  wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  sudo yum -y --nogpgcheck install epel-release-latest-7.noarch.rpm
+  sudo yum -y install epel-release
   if ! sudo yum -y install scons; then exit 1; fi
 fi
 
@@ -86,81 +85,9 @@ sudo yum -y --nogpgcheck install mysql57-community-release-el$RHEL_VERSION-9.noa
 if ! sudo yum -y install mysql-community-devel; then exit 1; fi
 sudo ln -s /usr/lib64/mysql/libmysqlclient.a /usr/lib64/libmysqlclient.a
 
-# Install cmake
-wget https://cmake.org/files/v3.7/cmake-3.7.0.tar.gz
-tar xf cmake-3.7.0.tar.gz
-cd cmake-3.7.0
-./configure
-if ! make -j $THREADS; then exit 1; fi
-sudo make install
-cd ..
-
-# Install Python 2.7
-if [ $RHEL_VERSION == 6 ]; then
-  wget https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz
-  tar xf Python-2.7.12.tar.xz
-  cd Python-2.7.12
-  ./configure
-  if ! make -j $THREADS; then exit 1; fi
-  sudo make altinstall
-  cd ..
-fi
-
-# Install GCC 6
-wget ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-6.2.0/gcc-6.2.0.tar.bz2
-tar xf gcc-6.2.0.tar.bz2
-cd gcc-6.2.0
-./contrib/download_prerequisites
-cd ..
-mkdir gcc-build
-cd gcc-build
-../gcc-6.2.0/configure --enable-languages=c,c++ --enable-linker-build-id --with-default-libstdcxx-abi=gcc4-compatible --disable-multilib
-if ! make -j $THREADS; then exit 1; fi
-sudo make install
-hash gcc g++
-gcc --version
-sudo ln -s /usr/local/bin/gcc /usr/local/bin/gcc-6
-sudo ln -s /usr/local/bin/g++ /usr/local/bin/g++-6
-sudo ln -s /usr/local/bin/gcc /usr/local/bin/cc
-sudo ln -s /usr/local/bin/g++ /usr/local/bin/c++
-cd ..
-
-# Use GCC 6 for builds
-export CC=gcc-6
-export CXX=g++-6
-
-# Install Boost
-wget http://downloads.sourceforge.net/project/boost/boost/1.62.0/boost_1_62_0.tar.bz2
-tar xf boost_1_62_0.tar.bz2
-cd boost_1_62_0
-if ! ./bootstrap.sh; then exit 1; fi
-if ! ./b2 --toolset=gcc-6 -j $THREADS; then exit 1; fi
-sudo PATH=$PATH ./b2 install --toolset=gcc-6 -j $THREADS
-cd ..
-
-# Install mongoclient from Git repo
-git clone -b legacy https://github.com/mongodb/mongo-cxx-driver.git
-cd mongo-cxx-driver
-if ! sudo PATH=$PATH scons --c++11 --release --cc=$CC --cxx=$CXX --ssl=0 --disable-warnings-as-errors -j $THREADS --prefix=/usr/local install; then exit 1; fi
-cd ..
-
-# Install Clang from Subversion repo
-mkdir llvm
-cd llvm
-svn co http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_390/final llvm
-cd llvm/tools
-svn co http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_390/final clang
-cd ..
-cd projects/
-svn co http://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_390/final compiler-rt
-cd ../..
-mkdir build
-cd build/
-cmake -D CMAKE_BUILD_TYPE:STRING=Release ../llvm -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,/usr/local/lib64 -L/usr/local/lib64"
-if ! make -j $THREADS; then exit 1; fi
-sudo make install
-hash clang
-cd ../..
+# Use dev GCC 6 for builds
+export CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
+export CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
 
 cd ..
 
@@ -185,7 +112,7 @@ wget https://github.com/yandex/ClickHouse/archive/v$CH_VERSION-$CH_TAG.zip
 mv v$CH_VERSION-$CH_TAG.zip ClickHouse-$CH_VERSION-$CH_TAG.zip
 cp *.zip ~/rpmbuild/SOURCES
 rpmbuild -bs clickhouse.spec
-CC=gcc-6 CXX=g++-6 rpmbuild -bb clickhouse.spec
+rpmbuild -bb clickhouse.spec
 
 }
 

--- a/rpm/clickhouse.spec.in
+++ b/rpm/clickhouse.spec.in
@@ -68,11 +68,14 @@ sed -i -- "s/VERSION_REVISION .*)/VERSION_REVISION ${CH_VERSION_ARR[2]})/g" dbms
 sed -i -- "s/VERSION_DESCRIBE .*)/VERSION_DESCRIBE v@CH_VERSION@-@CH_TAG@)/g" dbms/cmake/version.cmake
 
 %build
+export CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
+export CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
 rm -rf build
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE:STRING=Release
 make %{?_smp_mflags}
+make check
 cd ..
 
 %install
@@ -87,8 +90,8 @@ done
 cd ..
 
 mkdir -p $RPM_BUILD_ROOT/usr/share/clickhouse/bin $RPM_BUILD_ROOT/usr/share/clickhouse/headers
-debian/copy_clang_binaries.sh $RPM_BUILD_ROOT/usr/share/clickhouse/bin/
-./copy_headers.sh . $RPM_BUILD_ROOT/usr/share/clickhouse/headers
+#debian/copy_clang_binaries.sh $RPM_BUILD_ROOT/usr/share/clickhouse/bin/
+#./copy_headers.sh . $RPM_BUILD_ROOT/usr/share/clickhouse/headers
 
 cp -r %{_builddir}/%{buildsubdir}/tools/etc/* %{buildroot}/etc/
 


### PR DESCRIPTION
to build RPMs one the only needs this spec, clickhause archive in SOURCES and manualy(or from script) installed packets:

Centos 7:
yum -y install rpm-build redhat-rpm-config readline-devel\
 unixODBC-devel subversion epel-release mongo-cxx-driver centos-release-scl\
  cmake python boost boost-devel clang  python-devel git wget openssl-devel m4\
   createrepo glib2-devel libicu-devel zlib-devel libtool-ltdl-devel openssl-devel && sudo yum -y install scons devtoolset-6-gcc*

 wget http://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm

devel-gcc(g++)-6.2.1 will be installed
so there is no need in clang or compiled gcc

with standart packets except mysql57 everything is successfully compiling
